### PR TITLE
Bump Jetpack Compose to 1.1.1

### DIFF
--- a/buildSrc/src/main/kotlin/io/getstream/sketchbook/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/sketchbook/Dependencies.kt
@@ -12,7 +12,7 @@ object Versions {
     internal const val MATERIAL = "1.5.0"
     internal const val ANDROIDX_CORE_KTX = "1.5.0"
 
-    internal const val COMPOSE = "1.1.0"
+    internal const val COMPOSE = "1.1.1"
     internal const val COMPOSE_ACTIVITY = "1.4.0"
     internal const val COMPOSE_MATERIAL3 = "1.0.0-alpha02"
     internal const val COLOR_PICKER = "1.1.3"


### PR DESCRIPTION
### 🎯 Goal

Bump Jetpack Compose to [1.1.1](https://developer.android.com/jetpack/androidx/releases/compose-ui#version_11_2).